### PR TITLE
EROPSPT-274: Force a lower maximum page size (200)

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/ApiProperties.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/ApiProperties.kt
@@ -12,11 +12,14 @@ class ApiProperties(
     val defaultPageSize: Int,
     @Value("\${$MAX_PAGE_SIZE}")
     val maxPageSize: Int,
+    @Value("\${$FORCE_MAX_PAGE_SIZE}")
+    val forceMaxPageSize: Int,
 ) {
     companion object {
         private const val API_CONFIG_PREFIX = "dluhc"
         const val DEFAULT_PAGE_SIZE = "$API_CONFIG_PREFIX.default-page-size"
         const val MAX_PAGE_SIZE = "$API_CONFIG_PREFIX.max-page-size"
+        const val FORCE_MAX_PAGE_SIZE = "$API_CONFIG_PREFIX.force-max-page-size"
         const val REQUEST_HEADER_NAME = "$API_CONFIG_PREFIX.request.header.name"
         const val MAX_PAGE_SIZE_MIN_VALUE = 50
         const val DEFAULT_PAGE_SIZE_MIN_VALUE = 10

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationService.kt
@@ -29,8 +29,12 @@ class PostalVoteApplicationService(
     @Transactional(readOnly = true)
     fun getPostalVoteApplications(certificateSerialNumber: String, pageSize: Int?): PostalVoteApplications {
         val gssCodes = getGssCodes(certificateSerialNumber)
-        val numberOfRecordsToFetch = pageSize ?: apiProperties.defaultPageSize
+        var numberOfRecordsToFetch = pageSize ?: apiProperties.defaultPageSize
         logger.info("Fetching $pageSize applications from DB for Serial No=$certificateSerialNumber and gss codes = $gssCodes")
+        if (numberOfRecordsToFetch > apiProperties.forceMaxPageSize) {
+            logger.warn("Force setting number of records to fetch to ${apiProperties.forceMaxPageSize}, ignoring requested record count of $numberOfRecordsToFetch")
+            numberOfRecordsToFetch = apiProperties.forceMaxPageSize
+        }
         val postalApplicationIds = postalVoteApplicationRepository.findApplicationIdsByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
             gssCodes,
             RecordStatus.RECEIVED,

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationService.kt
@@ -30,8 +30,12 @@ class ProxyVoteApplicationService(
     fun getProxyVoteApplications(certificateSerialNumber: String, pageSize: Int?): ProxyVoteApplications {
         logger.info { "Proxy Service fetching GSS Codes for $certificateSerialNumber" }
         val gssCodes = retrieveGssCodeService.getGssCodeFromCertificateSerial(certificateSerialNumber)
-        val numberOfRecordsToFetch = pageSize ?: apiProperties.defaultPageSize
+        var numberOfRecordsToFetch = pageSize ?: apiProperties.defaultPageSize
         logger.info("Fetching $pageSize proxy vote applications from DB for Serial No=$certificateSerialNumber and gss codes = $gssCodes")
+        if (numberOfRecordsToFetch > apiProperties.forceMaxPageSize) {
+            logger.warn("Force setting number of records to fetch to ${apiProperties.forceMaxPageSize}, ignoring requested record count of $numberOfRecordsToFetch")
+            numberOfRecordsToFetch = apiProperties.forceMaxPageSize
+        }
         val proxyApplicationIds = proxyVoteApplicationRepository.findApplicationIdsByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
             gssCodes,
             RecordStatus.RECEIVED,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,7 @@ dluhc:
   request.header.name: ${REQUEST_HEADER_CLIENT_CERT_SERIAL}
   default-page-size: ${DEFAULT_PAGE_SIZE:100}
   max-page-size: ${MAX_PAGE_SIZE:500}
+  force-max-page-size: ${FORCE_MAX_PAGE_SIZE:200}
 
 cloud:
   aws:

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/config/ApiPropertiesTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/config/ApiPropertiesTest.kt
@@ -16,7 +16,8 @@ internal class ApiPropertiesTest {
             ApiProperties(
                 requestHeaderName = "something",
                 defaultPageSize = 10,
-                maxPageSize = 50
+                maxPageSize = 50,
+                forceMaxPageSize = 50
             ).validate()
         }
     }
@@ -27,7 +28,8 @@ internal class ApiPropertiesTest {
             ApiProperties(
                 requestHeaderName = "something",
                 defaultPageSize = 1,
-                maxPageSize = 50
+                maxPageSize = 50,
+                forceMaxPageSize = 50
             ).validate()
         }
         assertThat(configurationException.message).isEqualTo("The $DEFAULT_PAGE_SIZE value must be greater than or equal to $DEFAULT_PAGE_SIZE_MIN_VALUE")
@@ -39,7 +41,8 @@ internal class ApiPropertiesTest {
             ApiProperties(
                 requestHeaderName = "something",
                 defaultPageSize = 10,
-                maxPageSize = 1
+                maxPageSize = 1,
+                forceMaxPageSize = 1
             ).validate()
         }
         assertThat(applicationConfigurationException.message).isEqualTo("The $MAX_PAGE_SIZE value must be greater than or equal to $MAX_PAGE_SIZE_MIN_VALUE")
@@ -51,7 +54,8 @@ internal class ApiPropertiesTest {
             ApiProperties(
                 requestHeaderName = "something",
                 defaultPageSize = 51,
-                maxPageSize = 50
+                maxPageSize = 50,
+                forceMaxPageSize = 50
             ).validate()
         }
         assertThat(applicationConfigurationException.message).isEqualTo("The $DEFAULT_PAGE_SIZE value (51) must be less than $MAX_PAGE_SIZE value (50)")

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/rest/PageSizeValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/rest/PageSizeValidatorTest.kt
@@ -21,7 +21,8 @@ internal class PageSizeValidatorTest {
     private val apiProperties = ApiProperties(
         requestHeaderName = "test",
         defaultPageSize = 10,
-        maxPageSize = 20
+        maxPageSize = 20,
+        forceMaxPageSize = 20
     )
 
     private val validationErrorMessage =
@@ -31,7 +32,8 @@ internal class PageSizeValidatorTest {
         apiProperties = ApiProperties(
             requestHeaderName = "test",
             defaultPageSize = 10,
-            maxPageSize = 20
+            maxPageSize = 20,
+            forceMaxPageSize = 20
         )
     )
 

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
@@ -10,11 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.given
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.*
 import org.springframework.data.domain.Pageable
 import uk.gov.dluhc.emsintegrationapi.config.ApiProperties
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.DELETED_POSTAL_APPLICATION_QUEUE
@@ -84,6 +80,7 @@ internal class PostalVoteApplicationServiceTest {
         @AfterEach
         fun afterEach() {
             verify(apiProperties).defaultPageSize
+            verify(apiProperties, atLeastOnce()).forceMaxPageSize
         }
 
         @Test
@@ -113,9 +110,15 @@ internal class PostalVoteApplicationServiceTest {
 
     @Nested
     inner class PageSizeIsProvided {
+        @BeforeEach
+        fun beforeEach() {
+            given(apiProperties.forceMaxPageSize).willReturn(FORCE_MAX_PAGE_SIZE)
+        }
+
         @AfterEach
         fun afterEach() {
-            verifyNoInteractions(apiProperties)
+            verify(apiProperties, atLeastOnce()).forceMaxPageSize
+            verifyNoMoreInteractions(apiProperties)
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
@@ -57,6 +57,9 @@ internal class PostalVoteApplicationServiceTest {
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 100
+        private const val BETWEEN_DEFAULT_AND_FORCE_MAX_PAGE_SIZE = 150
+        private const val FORCE_MAX_PAGE_SIZE = 200
+        private const val MORE_THAN_FORCE_MAX_PAGE_SIZE = 250
         private const val CERTIFICATE_SERIAL_NUMBER = "test"
         private val GSS_CODES = listOf(GSS_CODE, GSS_CODE2)
         private val requestSuccess = EMSApplicationResponse()
@@ -75,6 +78,7 @@ internal class PostalVoteApplicationServiceTest {
         @BeforeEach
         fun beforeEach() {
             given(apiProperties.defaultPageSize).willReturn(DEFAULT_PAGE_SIZE)
+            given(apiProperties.forceMaxPageSize).willReturn(FORCE_MAX_PAGE_SIZE)
         }
 
         @AfterEach
@@ -83,16 +87,28 @@ internal class PostalVoteApplicationServiceTest {
         }
 
         @Test
-        fun `should return maximum of 100 postal vote applications`() =
-            validateFetchPostalVoteApplications(numberOfRecordsToBeReturned = 100, pageSizeRequested = null)
+        fun `should return maximum of DEFAULT_PAGE_SIZE postal vote applications`() =
+            validateFetchPostalVoteApplications(
+                numberOfRecordsToBeReturned = DEFAULT_PAGE_SIZE,
+                numberOfRecordsToBeRequested = DEFAULT_PAGE_SIZE,
+                pageSizeRequested = null
+            )
 
         @Test
         fun `system does not have requested number of records in the DB`() =
-            validateFetchPostalVoteApplications(numberOfRecordsToBeReturned = 10, pageSizeRequested = null)
+            validateFetchPostalVoteApplications(
+                numberOfRecordsToBeReturned = 10,
+                numberOfRecordsToBeRequested = DEFAULT_PAGE_SIZE,
+                pageSizeRequested = null
+            )
 
         @Test
         fun `system does not have any records`() =
-            validateFetchPostalVoteApplications(numberOfRecordsToBeReturned = 0, pageSizeRequested = null)
+            validateFetchPostalVoteApplications(
+                numberOfRecordsToBeReturned = 0,
+                numberOfRecordsToBeRequested = DEFAULT_PAGE_SIZE,
+                pageSizeRequested = null
+            )
     }
 
     @Nested
@@ -103,19 +119,43 @@ internal class PostalVoteApplicationServiceTest {
         }
 
         @Test
-        fun `should return maximum of 100 postal vote applications`() =
-            validateFetchPostalVoteApplications(numberOfRecordsToBeReturned = 100, pageSizeRequested = 200)
+        fun `should request and return maximum of FORCE_MAX_PAGE_SIZE postal vote applications`() =
+            validateFetchPostalVoteApplications(
+                numberOfRecordsToBeReturned = FORCE_MAX_PAGE_SIZE,
+                numberOfRecordsToBeRequested = FORCE_MAX_PAGE_SIZE,
+                pageSizeRequested = MORE_THAN_FORCE_MAX_PAGE_SIZE
+            )
+
+        @Test
+        fun `should request and return the page size requested postal vote applications`() =
+            validateFetchPostalVoteApplications(
+                numberOfRecordsToBeReturned = BETWEEN_DEFAULT_AND_FORCE_MAX_PAGE_SIZE,
+                numberOfRecordsToBeRequested = BETWEEN_DEFAULT_AND_FORCE_MAX_PAGE_SIZE,
+                pageSizeRequested = BETWEEN_DEFAULT_AND_FORCE_MAX_PAGE_SIZE
+            )
 
         @Test
         fun `system does not have requested number of records in the DB`() =
-            validateFetchPostalVoteApplications(numberOfRecordsToBeReturned = 10, pageSizeRequested = 100)
+            validateFetchPostalVoteApplications(
+                numberOfRecordsToBeReturned = 10,
+                numberOfRecordsToBeRequested = BETWEEN_DEFAULT_AND_FORCE_MAX_PAGE_SIZE,
+                pageSizeRequested = BETWEEN_DEFAULT_AND_FORCE_MAX_PAGE_SIZE
+            )
 
         @Test
         fun `system does not have any records`() =
-            validateFetchPostalVoteApplications(numberOfRecordsToBeReturned = 0, pageSizeRequested = 100)
+            validateFetchPostalVoteApplications(
+                numberOfRecordsToBeReturned = 0,
+                numberOfRecordsToBeRequested = BETWEEN_DEFAULT_AND_FORCE_MAX_PAGE_SIZE,
+                pageSizeRequested = BETWEEN_DEFAULT_AND_FORCE_MAX_PAGE_SIZE
+            )
     }
 
-    private fun validateFetchPostalVoteApplications(numberOfRecordsToBeReturned: Int, pageSizeRequested: Int?) {
+    private fun validateFetchPostalVoteApplications(
+        numberOfRecordsToBeReturned: Int,
+        numberOfRecordsToBeRequested: Int,
+        pageSizeRequested: Int?
+    ) {
         // Given
         val savedApplications =
             IntStream.rangeClosed(1, numberOfRecordsToBeReturned).mapToObj {
@@ -129,10 +169,12 @@ internal class PostalVoteApplicationServiceTest {
             postalVoteApplicationRepository.findApplicationIdsByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
                 GSS_CODES,
                 RecordStatus.RECEIVED,
-                Pageable.ofSize(pageSizeRequested ?: DEFAULT_PAGE_SIZE)
+                Pageable.ofSize(numberOfRecordsToBeRequested)
             )
         ).willReturn(savedApplicationIds)
-        given { postalVoteApplicationRepository.findByApplicationIdIn(savedApplicationIds) }.willReturn(savedApplications)
+        given { postalVoteApplicationRepository.findByApplicationIdIn(savedApplicationIds) }.willReturn(
+            savedApplications
+        )
         given { postalVoteMapper.mapFromEntities(savedApplications) }.willReturn(mockPostalVotes)
 
         val postalVoteApplications =
@@ -159,11 +201,18 @@ internal class PostalVoteApplicationServiceTest {
                 )
             ).willReturn(postalVoteApplication)
             // When
-            postalVoteApplicationService.confirmReceipt(CERTIFICATE_SERIAL_NUMBER, postalVoteApplication.applicationId, requestSuccess)
+            postalVoteApplicationService.confirmReceipt(
+                CERTIFICATE_SERIAL_NUMBER,
+                postalVoteApplication.applicationId,
+                requestSuccess
+            )
 
             // Then
             verify(messageSender).send(
-                EmsConfirmedReceiptMessage(postalVoteApplication.applicationId, EmsConfirmedReceiptMessage.Status.SUCCESS),
+                EmsConfirmedReceiptMessage(
+                    postalVoteApplication.applicationId,
+                    EmsConfirmedReceiptMessage.Status.SUCCESS
+                ),
                 DELETED_POSTAL_APPLICATION_QUEUE
             )
         }
@@ -179,8 +228,16 @@ internal class PostalVoteApplicationServiceTest {
                 )
             ).willReturn(postalVoteApplication)
             // When
-            val requestFailure = EMSApplicationResponse(status = EMSApplicationStatus.FAILURE, message = EMS_MESSAGE_TEXT, details = EMS_DETAILS_TEXT)
-            postalVoteApplicationService.confirmReceipt(CERTIFICATE_SERIAL_NUMBER, postalVoteApplication.applicationId, requestFailure)
+            val requestFailure = EMSApplicationResponse(
+                status = EMSApplicationStatus.FAILURE,
+                message = EMS_MESSAGE_TEXT,
+                details = EMS_DETAILS_TEXT
+            )
+            postalVoteApplicationService.confirmReceipt(
+                CERTIFICATE_SERIAL_NUMBER,
+                postalVoteApplication.applicationId,
+                requestFailure
+            )
 
             // Then
             verify(messageSender).send(
@@ -223,7 +280,11 @@ internal class PostalVoteApplicationServiceTest {
             ).willReturn(postalVoteApplication)
 
             // When
-            postalVoteApplicationService.confirmReceipt(CERTIFICATE_SERIAL_NUMBER, postalVoteApplication.applicationId, requestSuccess)
+            postalVoteApplicationService.confirmReceipt(
+                CERTIFICATE_SERIAL_NUMBER,
+                postalVoteApplication.applicationId,
+                requestSuccess
+            )
 
             // Then
             verify(postalVoteApplicationRepository).findByApplicationIdAndApplicationDetailsGssCodeIn(

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
@@ -10,7 +10,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.*
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.springframework.data.domain.Pageable
 import uk.gov.dluhc.emsintegrationapi.config.ApiProperties
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.DELETED_POSTAL_APPLICATION_QUEUE

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
@@ -10,11 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.given
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.*
 import org.springframework.data.domain.Pageable
 import uk.gov.dluhc.emsintegrationapi.config.ApiProperties
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration
@@ -75,11 +71,13 @@ internal class ProxyVoteApplicationServiceTest {
         @BeforeEach
         fun beforeEach() {
             given(apiProperties.defaultPageSize).willReturn(DEFAULT_PAGE_SIZE)
+            given(apiProperties.forceMaxPageSize).willReturn(FORCE_MAX_PAGE_SIZE)
         }
 
         @AfterEach
         fun afterEach() {
             verify(apiProperties).defaultPageSize
+            verify(apiProperties, atLeastOnce()).forceMaxPageSize
         }
 
         @Test
@@ -109,9 +107,16 @@ internal class ProxyVoteApplicationServiceTest {
 
     @Nested
     inner class PageSizeIsProvided {
-        @AfterEach
-        fun afterEach() = verifyNoInteractions(apiProperties)
+        @BeforeEach
+        fun beforeEach() {
+            given(apiProperties.forceMaxPageSize).willReturn(FORCE_MAX_PAGE_SIZE)
+        }
 
+        @AfterEach
+        fun afterEach() {
+            verify(apiProperties, atLeastOnce()).forceMaxPageSize
+            verifyNoMoreInteractions(apiProperties)
+        }
         @Test
         fun `should request and return maximum of FORCE_MAX_PAGE_SIZE proxy vote applications`() =
             validateFetchProxyVoteApplications(

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
@@ -10,7 +10,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.*
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.springframework.data.domain.Pageable
 import uk.gov.dluhc.emsintegrationapi.config.ApiProperties
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration
@@ -117,6 +122,7 @@ internal class ProxyVoteApplicationServiceTest {
             verify(apiProperties, atLeastOnce()).forceMaxPageSize
             verifyNoMoreInteractions(apiProperties)
         }
+
         @Test
         fun `should request and return maximum of FORCE_MAX_PAGE_SIZE proxy vote applications`() =
             validateFetchProxyVoteApplications(
@@ -150,7 +156,11 @@ internal class ProxyVoteApplicationServiceTest {
             )
     }
 
-    private fun validateFetchProxyVoteApplications(numberOfRecordsToBeReturned: Int, numberOfRecordsToBeRequested: Int, pageSizeRequested: Int?) {
+    private fun validateFetchProxyVoteApplications(
+        numberOfRecordsToBeReturned: Int,
+        numberOfRecordsToBeRequested: Int,
+        pageSizeRequested: Int?
+    ) {
         // Given
         val savedApplications =
             IntStream.rangeClosed(1, numberOfRecordsToBeReturned).mapToObj {
@@ -200,7 +210,10 @@ internal class ProxyVoteApplicationServiceTest {
 
             // Then
             verify(messageSender).send(
-                EmsConfirmedReceiptMessage(proxyVoteApplication.applicationId, EmsConfirmedReceiptMessage.Status.SUCCESS),
+                EmsConfirmedReceiptMessage(
+                    proxyVoteApplication.applicationId,
+                    EmsConfirmedReceiptMessage.Status.SUCCESS
+                ),
                 QueueConfiguration.QueueName.DELETED_PROXY_APPLICATION_QUEUE
             )
         }
@@ -216,8 +229,16 @@ internal class ProxyVoteApplicationServiceTest {
                 )
             ).willReturn(proxyVoteApplication)
             // When
-            val requestFailure = EMSApplicationResponse(status = EMSApplicationStatus.FAILURE, message = ApplicationConstants.EMS_MESSAGE_TEXT, details = ApplicationConstants.EMS_DETAILS_TEXT)
-            proxyVoteApplicationService.confirmReceipt(CERTIFICATE_SERIAL_NUMBER, proxyVoteApplication.applicationId, requestFailure)
+            val requestFailure = EMSApplicationResponse(
+                status = EMSApplicationStatus.FAILURE,
+                message = ApplicationConstants.EMS_MESSAGE_TEXT,
+                details = ApplicationConstants.EMS_DETAILS_TEXT
+            )
+            proxyVoteApplicationService.confirmReceipt(
+                CERTIFICATE_SERIAL_NUMBER,
+                proxyVoteApplication.applicationId,
+                requestFailure
+            )
 
             // Then
             verify(messageSender).send(

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -17,6 +17,7 @@ dluhc:
   request.header.name: client-cert-serial
   default-page-size: 20
   max-page-size: 50
+  force-max-page-size: 50
 cloud:
   aws:
     region:


### PR DESCRIPTION
Signatures are around 20KB on average, so a page size of 500 corresponds to around 10MB of data, which goes over the limit that can be passed through an API Gateway.

This change forces at most 200 applications to be returned, even if more than 200 applications are requested. Requests with a page size over 200 are still accepted, while EMS's are given time to adapt to the change.