### PR TITLE
EROPSPT-274: Update API spec to reduce maximum pageSize to 200

### DIFF
--- a/src/main/resources/openapi/EMSIntegrationAPIs.yaml
+++ b/src/main/resources/openapi/EMSIntegrationAPIs.yaml
@@ -82,7 +82,7 @@ paths:
             type: integer
           in: query
           name: pageSize
-          description: 'The maximum number of records to return in the response. Default 100, min 1, max 500'
+          description: 'The maximum number of records to return in the response. Default 100, min 1, max 200'
       security:
         - emsCertificateLambdaAuthorizer: []
       x-amazon-apigateway-integration:
@@ -209,7 +209,7 @@ paths:
             type: number
           in: query
           name: pageSize
-          description: 'The maximum number of records to return in the response. Default 100, min 1, max 500'
+          description: 'The maximum number of records to return in the response. Default 100, min 1, max 200'
       security:
         - emsCertificateLambdaAuthorizer: [ ]
       x-amazon-apigateway-integration:


### PR DESCRIPTION
Barnsley appear to have been able to download some records this morning, so it seems like the new forced limit is working!

It would be good to get EMS's to make this change on their side eventually, as for example they might think they have got all of the records if they think the page size is 200. Duncan is writing a change request to share with EMS's, this is the change to the API spec.