### PR TITLE
EROPSPT-298: Add information on presence of EMS Elector Ids in monitoring

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/PendingDownloadsSummaryByGssCode.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/PendingDownloadsSummaryByGssCode.kt
@@ -3,4 +3,5 @@ package uk.gov.dluhc.emsintegrationapi.database.entity
 interface PendingDownloadsSummaryByGssCode {
     val gssCode: String
     val pendingDownloadCount: Int
+    val pendingDownloadsWithEmsElectorId: Int
 }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/PostalVoteApplicationRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/PostalVoteApplicationRepository.kt
@@ -36,7 +36,10 @@ interface PostalVoteApplicationRepository :
     ): PostalVoteApplication?
 
     @Query(
-        """SELECT app.applicationDetails.gssCode AS gssCode, count(app.applicationId) as pendingDownloadCount
+        """SELECT
+            app.applicationDetails.gssCode AS gssCode,
+            count(app.applicationId) as pendingDownloadCount,
+            count(app.applicantDetails.emsElectorId) as pendingDownloadsWithEmsElectorId
         FROM PostalVoteApplication app
         WHERE app.status = 'RECEIVED' AND app.dateCreated < :createdBefore
         GROUP BY app.applicationDetails.gssCode

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/ProxyVoteApplicationRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/ProxyVoteApplicationRepository.kt
@@ -36,7 +36,10 @@ interface ProxyVoteApplicationRepository :
     ): ProxyVoteApplication?
 
     @Query(
-        """SELECT app.applicationDetails.gssCode AS gssCode, count(app.applicationId) as pendingDownloadCount
+        """SELECT
+            app.applicationDetails.gssCode AS gssCode,
+            count(app.applicationId) as pendingDownloadCount,
+            count(app.applicantDetails.emsElectorId) as pendingDownloadsWithEmsElectorId
         FROM ProxyVoteApplication app
         WHERE app.status = 'RECEIVED' AND app.dateCreated < :createdBefore
         GROUP BY app.applicationDetails.gssCode

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PendingDownloadsMonitoringService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PendingDownloadsMonitoringService.kt
@@ -36,11 +36,17 @@ class PendingDownloadsMonitoringService(
     private fun logPendingDownloads(applicationType: String, summaries: List<PendingDownloadsSummaryByGssCode>) {
         val nonExcludedPendingDownloadSummaries = summaries.filter { !excludedGssCodes.contains(it.gssCode) }
         val totalPending = nonExcludedPendingDownloadSummaries.sumOf { it.pendingDownloadCount }
+        val totalPendingWithEmsElectorId =
+            nonExcludedPendingDownloadSummaries.sumOf { it.pendingDownloadsWithEmsElectorId }
 
-        logger.info { "A total of $totalPending $applicationType applications have been pending for more than $expectedMaximumPendingPeriod." }
+        logger.info {
+            "A total of $totalPending $applicationType applications ($totalPendingWithEmsElectorId with EMS " +
+                "Elector Ids) have been pending for more than $expectedMaximumPendingPeriod."
+        }
         nonExcludedPendingDownloadSummaries.forEach {
             logger.info {
                 "The gss code ${it.gssCode} has ${it.pendingDownloadCount} $applicationType applications " +
+                    "(${it.pendingDownloadsWithEmsElectorId} with EMS Elector Ids) " +
                     "that have been pending for more than $expectedMaximumPendingPeriod."
             }
         }

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/cucumber/database/PostalVoteApplicationSteps.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/cucumber/database/PostalVoteApplicationSteps.kt
@@ -1,8 +1,10 @@
 package uk.gov.dluhc.emsintegrationapi.cucumber.database
 
 import io.cucumber.java8.En
+import uk.gov.dluhc.emsintegrationapi.database.entity.PostalVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
 import uk.gov.dluhc.emsintegrationapi.database.repository.PostalVoteApplicationRepository
+import uk.gov.dluhc.emsintegrationapi.testsupport.testdata.buildApplicantDetailsEntity
 import uk.gov.dluhc.emsintegrationapi.testsupport.testdata.buildApplicationDetailsEntity
 import uk.gov.dluhc.emsintegrationapi.testsupport.testdata.buildPostalVoteApplication
 import java.time.Instant
@@ -12,14 +14,38 @@ open class PostalVoteApplicationSteps(
     private val postalVoteApplicationRepository: PostalVoteApplicationRepository,
 ) : En {
     init {
-        Given("a postal vote application with gss code {string} was saved to EMS integration API {int} days ago and has record status {string}") { gssCode: String, numberOfDays: Int, recordStatus: String ->
+        Given(
+            "a postal vote application with gss code {string} was saved to EMS integration API {int} days ago and has record status {string}",
+            ::createPostalApplicationWithEmsElectorId
+        )
+
+        Given(
+            "a postal vote application with gss code {string} with an EMS Elector ID was saved to EMS integration API {int} days ago and has record status {string}",
+            ::createPostalApplicationWithEmsElectorId
+        )
+
+        Given("a postal vote application with gss code {string} without an EMS Elector ID was saved to EMS integration API {int} days ago and has record status {string}") { gssCode: String, numberOfDays: Int, recordStatus: String ->
             val postalVoteApplication = buildPostalVoteApplication(
                 recordStatus = RecordStatus.valueOf(recordStatus),
-                applicationDetails = buildApplicationDetailsEntity(gssCode = gssCode)
+                applicationDetails = buildApplicationDetailsEntity(gssCode = gssCode),
+                applicantDetails = buildApplicantDetailsEntity(emsElectorId = null)
             )
-            postalVoteApplicationRepository.save(postalVoteApplication)
-            postalVoteApplication.dateCreated = Instant.now().minus(Period.ofDays(numberOfDays))
-            postalVoteApplicationRepository.save(postalVoteApplication)
+            setDateCreatedToDaysAgo(postalVoteApplication, numberOfDays)
         }
+    }
+
+    private fun createPostalApplicationWithEmsElectorId(gssCode: String, numberOfDays: Int, recordStatus: String) {
+        val postalVoteApplication = buildPostalVoteApplication(
+            recordStatus = RecordStatus.valueOf(recordStatus),
+            applicationDetails = buildApplicationDetailsEntity(gssCode = gssCode)
+        )
+        setDateCreatedToDaysAgo(postalVoteApplication, numberOfDays)
+    }
+
+    private fun setDateCreatedToDaysAgo(application: PostalVoteApplication, daysAgo: Int) {
+        // Application needs to be saved first to avoid the date created being overwritten
+        postalVoteApplicationRepository.save(application)
+        application.dateCreated = Instant.now().minus(Period.ofDays(daysAgo))
+        postalVoteApplicationRepository.save(application)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/cucumber/database/ProxyVoteApplicationSteps.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/cucumber/database/ProxyVoteApplicationSteps.kt
@@ -1,8 +1,10 @@
 package uk.gov.dluhc.emsintegrationapi.cucumber.database
 
 import io.cucumber.java8.En
+import uk.gov.dluhc.emsintegrationapi.database.entity.ProxyVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
 import uk.gov.dluhc.emsintegrationapi.database.repository.ProxyVoteApplicationRepository
+import uk.gov.dluhc.emsintegrationapi.testsupport.testdata.buildApplicantDetailsEntity
 import uk.gov.dluhc.emsintegrationapi.testsupport.testdata.buildApplicationDetailsEntity
 import uk.gov.dluhc.emsintegrationapi.testsupport.testdata.buildProxyVoteApplication
 import java.time.Instant
@@ -12,14 +14,38 @@ open class ProxyVoteApplicationSteps(
     private val proxyVoteApplicationRepository: ProxyVoteApplicationRepository,
 ) : En {
     init {
-        Given("a proxy vote application with gss code {string} was saved to EMS integration API {int} days ago and has record status {string}") { gssCode: String, numberOfDays: Int, recordStatus: String ->
+        Given(
+            "a proxy vote application with gss code {string} was saved to EMS integration API {int} days ago and has record status {string}",
+            ::createProxyApplicationWithEmsElectorId
+        )
+
+        Given(
+            "a proxy vote application with gss code {string} with an EMS Elector ID was saved to EMS integration API {int} days ago and has record status {string}",
+            ::createProxyApplicationWithEmsElectorId
+        )
+
+        Given("a proxy vote application with gss code {string} without an EMS Elector ID was saved to EMS integration API {int} days ago and has record status {string}") { gssCode: String, numberOfDays: Int, recordStatus: String ->
             val proxyVoteApplication = buildProxyVoteApplication(
                 recordStatus = RecordStatus.valueOf(recordStatus),
-                applicationDetails = buildApplicationDetailsEntity(gssCode = gssCode)
+                applicationDetails = buildApplicationDetailsEntity(gssCode = gssCode),
+                applicantDetails = buildApplicantDetailsEntity(emsElectorId = null)
             )
-            proxyVoteApplicationRepository.save(proxyVoteApplication)
-            proxyVoteApplication.dateCreated = Instant.now().minus(Period.ofDays(numberOfDays))
-            proxyVoteApplicationRepository.save(proxyVoteApplication)
+            setDateCreatedToDaysAgo(proxyVoteApplication, numberOfDays)
         }
+    }
+
+    private fun createProxyApplicationWithEmsElectorId(gssCode: String, numberOfDays: Int, recordStatus: String) {
+        val proxyVoteApplication = buildProxyVoteApplication(
+            recordStatus = RecordStatus.valueOf(recordStatus),
+            applicationDetails = buildApplicationDetailsEntity(gssCode = gssCode)
+        )
+        setDateCreatedToDaysAgo(proxyVoteApplication, numberOfDays)
+    }
+
+    private fun setDateCreatedToDaysAgo(application: ProxyVoteApplication, daysAgo: Int) {
+        // Application needs to be saved first to avoid the date created being overwritten
+        proxyVoteApplicationRepository.save(application)
+        application.dateCreated = Instant.now().minus(Period.ofDays(daysAgo))
+        proxyVoteApplicationRepository.save(application)
     }
 }

--- a/src/test/resources/features/monitoring-pending-downloads.feature
+++ b/src/test/resources/features/monitoring-pending-downloads.feature
@@ -5,19 +5,19 @@ Feature: System reports on pending postal and proxy downloads
   Scenario: System does not report on pending postal downloads that are less than 5 days old
     Given a postal vote application with gss code "E00000001" was saved to EMS integration API 3 days ago and has record status "RECEIVED"
     When the pending downloads monitoring job runs
-    Then the message "A total of 0 postal applications have been pending for more than PT120H." is logged
+    Then the message "A total of 0 postal applications (0 with EMS Elector Ids) have been pending for more than PT120H." is logged
 
   @DeletePostalEntity
   Scenario: System does not report on postal downloads that have been deleted
     Given a postal vote application with gss code "E00000001" was saved to EMS integration API 6 days ago and has record status "DELETED"
     When the pending downloads monitoring job runs
-    Then the message "A total of 0 postal applications have been pending for more than PT120H." is logged
+    Then the message "A total of 0 postal applications (0 with EMS Elector Ids) have been pending for more than PT120H." is logged
 
   @DeletePostalEntity
   Scenario: System does not report on pending postal downloads from excluded GSS codes
     Given a postal vote application with gss code "E99999999" was saved to EMS integration API 6 days ago and has record status "RECEIVED"
     When the pending downloads monitoring job runs
-    Then the message "A total of 0 postal applications have been pending for more than PT120H." is logged
+    Then the message "A total of 0 postal applications (0 with EMS Elector Ids) have been pending for more than PT120H." is logged
 
   @DeletePostalEntity
   Scenario: System reports on postal downloads that have been pending for more than 5 days, grouped by gss code
@@ -26,27 +26,38 @@ Feature: System reports on pending postal and proxy downloads
     And a postal vote application with gss code "E00000001" was saved to EMS integration API 8 days ago and has record status "RECEIVED"
     And a postal vote application with gss code "E00000002" was saved to EMS integration API 6 days ago and has record status "RECEIVED"
     When the pending downloads monitoring job runs
-    Then the message "A total of 4 postal applications have been pending for more than PT120H." is logged
-    And the message "The gss code E00000001 has 3 postal applications that have been pending for more than PT120H." is logged
-    And the message "The gss code E00000002 has 1 postal applications that have been pending for more than PT120H." is logged
+    Then the message "A total of 4 postal applications (4 with EMS Elector Ids) have been pending for more than PT120H." is logged
+    And the message "The gss code E00000001 has 3 postal applications (3 with EMS Elector Ids) that have been pending for more than PT120H." is logged
+    And the message "The gss code E00000002 has 1 postal applications (1 with EMS Elector Ids) that have been pending for more than PT120H." is logged
+
+  @DeletePostalEntity
+  Scenario: System reports number of pending postal downloads with an EMS Elector ID separately
+    Given a postal vote application with gss code "E00000001" with an EMS Elector ID was saved to EMS integration API 6 days ago and has record status "RECEIVED"
+    And a postal vote application with gss code "E00000001" without an EMS Elector ID was saved to EMS integration API 7 days ago and has record status "RECEIVED"
+    And a postal vote application with gss code "E00000001" without an EMS Elector ID was saved to EMS integration API 8 days ago and has record status "RECEIVED"
+    And a postal vote application with gss code "E00000002" without an EMS Elector ID was saved to EMS integration API 6 days ago and has record status "RECEIVED"
+    When the pending downloads monitoring job runs
+    Then the message "A total of 4 postal applications (1 with EMS Elector Ids) have been pending for more than PT120H." is logged
+    And the message "The gss code E00000001 has 3 postal applications (1 with EMS Elector Ids) that have been pending for more than PT120H." is logged
+    And the message "The gss code E00000002 has 1 postal applications (0 with EMS Elector Ids) that have been pending for more than PT120H." is logged
 
   @DeleteProxyEntity
   Scenario: System does not report on pending proxy downloads that are less than 5 days old
     Given a proxy vote application with gss code "E00000001" was saved to EMS integration API 3 days ago and has record status "RECEIVED"
     When the pending downloads monitoring job runs
-    Then the message "A total of 0 proxy applications have been pending for more than PT120H." is logged
+    Then the message "A total of 0 proxy applications (0 with EMS Elector Ids) have been pending for more than PT120H." is logged
 
   @DeleteProxyEntity
   Scenario: System does not report on proxy downloads that have been deleted
     Given a proxy vote application with gss code "E00000001" was saved to EMS integration API 6 days ago and has record status "DELETED"
     When the pending downloads monitoring job runs
-    Then the message "A total of 0 proxy applications have been pending for more than PT120H." is logged
+    Then the message "A total of 0 proxy applications (0 with EMS Elector Ids) have been pending for more than PT120H." is logged
 
   @DeleteProxyEntity
   Scenario: System does not report on pending proxy downloads from excluded GSS codes
     Given a proxy vote application with gss code "E99999999" was saved to EMS integration API 6 days ago and has record status "RECEIVED"
     When the pending downloads monitoring job runs
-    Then the message "A total of 0 proxy applications have been pending for more than PT120H." is logged
+    Then the message "A total of 0 proxy applications (0 with EMS Elector Ids) have been pending for more than PT120H." is logged
 
   @DeleteProxyEntity
   Scenario: System reports on proxy downloads that have been pending for more than 5 days, grouped by gss code
@@ -55,6 +66,17 @@ Feature: System reports on pending postal and proxy downloads
     And a proxy vote application with gss code "E00000001" was saved to EMS integration API 8 days ago and has record status "RECEIVED"
     And a proxy vote application with gss code "E00000002" was saved to EMS integration API 6 days ago and has record status "RECEIVED"
     When the pending downloads monitoring job runs
-    Then the message "A total of 4 proxy applications have been pending for more than PT120H." is logged
-    And the message "The gss code E00000001 has 3 proxy applications that have been pending for more than PT120H." is logged
-    And the message "The gss code E00000002 has 1 proxy applications that have been pending for more than PT120H." is logged
+    Then the message "A total of 4 proxy applications (4 with EMS Elector Ids) have been pending for more than PT120H." is logged
+    And the message "The gss code E00000001 has 3 proxy applications (3 with EMS Elector Ids) that have been pending for more than PT120H." is logged
+    And the message "The gss code E00000002 has 1 proxy applications (1 with EMS Elector Ids) that have been pending for more than PT120H." is logged
+
+  @DeleteProxyEntity
+  Scenario: System reports number of pending proxy downloads with an EMS Elector ID separately
+    Given a proxy vote application with gss code "E00000001" with an EMS Elector ID was saved to EMS integration API 6 days ago and has record status "RECEIVED"
+    And a proxy vote application with gss code "E00000001" without an EMS Elector ID was saved to EMS integration API 7 days ago and has record status "RECEIVED"
+    And a proxy vote application with gss code "E00000001" without an EMS Elector ID was saved to EMS integration API 8 days ago and has record status "RECEIVED"
+    And a proxy vote application with gss code "E00000002" without an EMS Elector ID was saved to EMS integration API 6 days ago and has record status "RECEIVED"
+    When the pending downloads monitoring job runs
+    Then the message "A total of 4 proxy applications (1 with EMS Elector Ids) have been pending for more than PT120H." is logged
+    And the message "The gss code E00000001 has 3 proxy applications (1 with EMS Elector Ids) that have been pending for more than PT120H." is logged
+    And the message "The gss code E00000002 has 1 proxy applications (0 with EMS Elector Ids) that have been pending for more than PT120H." is logged


### PR DESCRIPTION
This information is very useful for identifying genuine issues at the moment as some applications without an EMS Elector ID get put in a holding area on the EMS side, and do not get responded to until later. The EMS behaviour may change in the future as it comes with some problems, and these applications still need some attention paid to them, otherwise they can block other downloads.