### PR TITLE
EROPSPT-298: Remove index on date created

### DIFF
--- a/src/main/resources/db/changelog/create/0020_EROPSPT-298_remove_date_created_index.xml
+++ b/src/main/resources/db/changelog/create/0020_EROPSPT-298_remove_date_created_index.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="kirsty.land@softwire.com" id="0020_EROPSPT-298_remove_date_created_index" context="ddl">
+        <dropIndex tableName="postal_vote_application" indexName="postal_vote_application_date_created_idx"/>
+        <dropIndex tableName="proxy_vote_application" indexName="proxy_vote_application_date_created_idx"/>
+
+        <rollback>
+            <createIndex tableName="postal_vote_application" indexName="postal_vote_application_date_created_idx">
+                <column name="date_created"/>
+            </createIndex>
+            <createIndex tableName="proxy_vote_application" indexName="proxy_vote_application_date_created_idx">
+                <column name="date_created"/>
+            </createIndex>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -37,3 +37,5 @@ databaseChangeLog:
       file: /db/changelog/create/0018_EIP1-9508_add_gss_code_status_date_created_indexes.xml
   - include:
       file: /db/changelog/create/0019_EROPSPT-298_add_shedlock_table.xml
+  - include:
+      file: /db/changelog/create/0020_EROPSPT-298_remove_date_created_index.xml


### PR DESCRIPTION
This index was originally created to resolve an issues where the sort buffer could be exhausted with signature data. A different fix was later added to implement a two-step retrieval process.

We have seen this index used inefficiently for finding ERO downloads on live - that problem was resolved by adding a new index. We've also seen this index used when the monitoring queries are running, and the queries run more slowly when using this index than when forced to use the index on gss code, status and date created.

---

There is some risk that the index is still doing something useful, so if we release this change we will want to monitor ems integration api for 5xx errors and reinstate the index if we see problems.