### PR TITLE
EROPSPT-319: Add correlation ids to logging for api requests

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/IerRestTemplateConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/IerRestTemplateConfiguration.kt
@@ -25,7 +25,8 @@ import java.net.URI
 @Configuration
 class IerRestTemplateConfiguration(
     @Value("\${api.ier.base.url}") private val ierApiBaseUrl: String,
-    @Value("\${api.ier.sts.assume.role}") private val ierStsAssumeRole: String
+    @Value("\${api.ier.sts.assume.role}") private val ierStsAssumeRole: String,
+    private val correlationIdRestTemplateClientHttpRequestInterceptor: CorrelationIdRestTemplateClientHttpRequestInterceptor,
 ) {
 
     companion object {
@@ -38,6 +39,7 @@ class IerRestTemplateConfiguration(
         return RestTemplateBuilder()
             .requestFactory { ierClientHttpRequestFactory }
             .rootUri(ierApiBaseUrl)
+            .interceptors(correlationIdRestTemplateClientHttpRequestInterceptor)
             .build()
     }
 

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/WebClientConfiguration.kt
@@ -6,11 +6,14 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
-class WebClientConfiguration {
+class WebClientConfiguration(
+    private val correlationIdExchangeFilter: CorrelationIdWebClientMdcExchangeFilter
+) {
 
     @Bean
     fun eroManagementWebClient(@Value("\${api.ero-management.url}") eroManagementApiUrl: String): WebClient =
         WebClient.builder()
             .baseUrl(eroManagementApiUrl)
+            .filter(correlationIdExchangeFilter)
             .build()
 }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/WebMvcConfig.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package uk.gov.dluhc.emsintegrationapi.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(private val correlationIdMdcInterceptor: CorrelationIdMdcInterceptor) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(correlationIdMdcInterceptor)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/logging/CorrelationIdMdcIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/logging/CorrelationIdMdcIntegrationTest.kt
@@ -11,6 +11,13 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.dluhc.emsintegrationapi.config.ApiProperties
+import uk.gov.dluhc.emsintegrationapi.config.CORRELATION_ID
+import uk.gov.dluhc.emsintegrationapi.config.CORRELATION_ID_HEADER
+import uk.gov.dluhc.emsintegrationapi.config.ERO_CERTIFICATE_MAPPING_CACHE
+import uk.gov.dluhc.emsintegrationapi.config.ERO_GSS_CODE_BY_ERO_ID_CACHE
 import uk.gov.dluhc.emsintegrationapi.config.IntegrationTest
 import uk.gov.dluhc.emsintegrationapi.cucumber.common.StepHelper.Companion.deleteRecords
 import uk.gov.dluhc.emsintegrationapi.cucumber.common.StepHelper.Companion.deleteSqsMessage
@@ -18,6 +25,7 @@ import uk.gov.dluhc.emsintegrationapi.cucumber.common.StepHelper.TestPhase
 import uk.gov.dluhc.emsintegrationapi.database.repository.PostalVoteApplicationRepository
 import uk.gov.dluhc.emsintegrationapi.testsupport.TestLogAppender
 import uk.gov.dluhc.emsintegrationapi.testsupport.TestLogAppender.Companion.logs
+import uk.gov.dluhc.emsintegrationapi.testsupport.WiremockService
 import uk.gov.dluhc.emsintegrationapi.testsupport.assertj.assertions.ILoggingEventAssert.Companion.assertThat
 import uk.gov.dluhc.emsintegrationapi.testsupport.testdata.buildPostalVoteApplicationMessage
 import java.util.UUID.randomUUID
@@ -44,6 +52,97 @@ internal class CorrelationIdMdcIntegrationTest : IntegrationTest() {
 
     @Autowired
     protected lateinit var amazonSQSAsync: AmazonSQSAsync
+
+    @Autowired
+    protected lateinit var wireMockService: WiremockService
+
+    @Autowired
+    protected lateinit var webClient: WebTestClient
+
+    @Autowired
+    protected lateinit var apiProperties: ApiProperties
+
+    @Autowired
+    protected lateinit var cacheManager: CacheManager
+
+    @AfterEach
+    fun tearDown() {
+        TestLogAppender.reset()
+        cacheManager.getCache(ERO_CERTIFICATE_MAPPING_CACHE)?.clear()
+        cacheManager.getCache(ERO_GSS_CODE_BY_ERO_ID_CACHE)?.clear()
+    }
+
+    @Nested
+    inner class PostalVoteApplicationRequest {
+
+        private val PATH = "/postalvotes"
+        private val CERTIFICATE_SERIAL_NUMBER = "543219999"
+        private val ERO_ID = "test-ero"
+
+        @BeforeEach
+        fun setupWiremockStubs() {
+            wireMockService.stubIerApiGetEroIdentifier(CERTIFICATE_SERIAL_NUMBER, ERO_ID)
+            wireMockService.stubEroManagementGetEro(ERO_ID)
+        }
+
+        @Test
+        fun `should service REST API call given no correlation-id header`() {
+            // When
+            webClient.get().uri(PATH)
+                .header(apiProperties.requestHeaderName, CERTIFICATE_SERIAL_NUMBER)
+                .exchange()
+
+            // Then
+            await.atMost(3, TimeUnit.SECONDS).untilAsserted {
+                val firstReliableMessage = TestLogAppender.getLogEventMatchingRegex(
+                    "Processing a get postal vote applications request with page size =null and certificate serial no =$CERTIFICATE_SERIAL_NUMBER",
+                    Level.INFO
+                )
+                assertThat(firstReliableMessage).hasAnyCorrelationId()
+                val correlationId = firstReliableMessage!!.mdcPropertyMap[CORRELATION_ID]!!
+
+                val filteredLogs = logs.filter { it.mdcPropertyMap.isNotEmpty() }
+                // wait until sufficient messages are logged before verifying all share same correlation ID
+                assertThat(filteredLogs).hasSizeGreaterThanOrEqualTo(3)
+
+                filteredLogs.forEach {
+                    assertThat(it).`as`("Message: ${it.message}").hasCorrelationId(correlationId)
+                }
+                wireMockService.verifyIerApiRequestWithCorrelationId(correlationId)
+                wireMockService.verifyEroManagementApiRequestWithCorrelationId(correlationId)
+            }
+        }
+
+        @Test
+        fun `should service REST API call given correlation-id header`() {
+            // When
+            val expectedCorrelationId = randomUUID().toString().replace("-", "")
+            webClient.get().uri(PATH)
+                .header(apiProperties.requestHeaderName, CERTIFICATE_SERIAL_NUMBER)
+                .header(CORRELATION_ID_HEADER, expectedCorrelationId)
+                .exchange()
+
+            // Then
+            await.atMost(3, TimeUnit.SECONDS).untilAsserted {
+                assertThat(
+                    TestLogAppender.getLogEventMatchingRegex(
+                        "Processing a get postal vote applications request with page size =null and certificate serial no =$CERTIFICATE_SERIAL_NUMBER",
+                        Level.INFO
+                    )
+                ).hasCorrelationId(expectedCorrelationId)
+
+                val filteredLogs = logs.filter { it.mdcPropertyMap.isNotEmpty() }
+                // wait until sufficient messages are logged before verifying all share same correlation ID
+                assertThat(filteredLogs).hasSizeGreaterThanOrEqualTo(3)
+
+                filteredLogs.forEach {
+                    assertThat(it).`as`("Message: ${it.message}").hasCorrelationId(expectedCorrelationId)
+                }
+                wireMockService.verifyIerApiRequestWithCorrelationId(expectedCorrelationId)
+                wireMockService.verifyEroManagementApiRequestWithCorrelationId(expectedCorrelationId)
+            }
+        }
+    }
 
     @Nested
     inner class PostalVoteApplicationSqs {
@@ -96,5 +195,3 @@ internal class CorrelationIdMdcIntegrationTest : IntegrationTest() {
 }
 
 // TODO placeholder to add test for scheduled jobs when we have them!
-
-// TODO placeholder to add test for interaction with RestTemplate when we integrate with IER


### PR DESCRIPTION
Code for CorrelationIdRestTemplateClientHttpRequestInterceptor copied from logging library - not sure why the shared libraries aren't used in newer services though, possibly I should be sorting that out as well but the tests are still helpful as the missing code was mostly configuration.