### PR TITLE
EROPSPT-NONE - Downgrade Docker to fix building app images

### DIFF
--- a/.github/workflows/build-image-and-deploy-to-dev.yml
+++ b/.github/workflows/build-image-and-deploy-to-dev.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   build-and-tag:
-    runs-on: ubuntu-latest
+    # Pin to ubuntu 22.04 for as long as we manually install a specific Docker version
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.bump-semver.outputs.new_version }}
     steps:
@@ -52,6 +53,21 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git tag -a "${tag}" -m "${{ github.event.head_commit.message }}"
           git push origin "${tag}"
+
+      # https://github.com/spring-projects/spring-boot/issues/39323
+      # Spring Boot 2 has a bug in the way it installs buildpacks which is
+      # not compatible with Docker versions >= 25.
+      - name: Install Docker version 24 for compatibility with Spring Boot 2
+        run: |
+          VERSION_STRING=5:24.0.9-1~ubuntu.22.04~jammy
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image


### PR DESCRIPTION
The latest GitHub runner images have upgraded to Docker 26.

There's an incompatibility between Spring Boot 2 and Docker versions >= 25 when it comes to installing buildpacks, which causes bootBuildImage to fail.

Failed action: https://github.com/communitiesuk/eip-ero-ems-integration-api/actions/runs/9514574614
Issue thread: https://github.com/spring-projects/spring-boot/issues/39323

(Temporarily) downgrade to Docker 24 for as long as this project is not upgraded to SB 3. This will need to be replicated on the other SB 2 projects.