### PR TITLE
EROPSPT-350: Review indexes on EMS integration API tables

### DIFF
--- a/src/main/resources/db/changelog/create/0021_EROPSPT-350_remove_unused_indexes.xml
+++ b/src/main/resources/db/changelog/create/0021_EROPSPT-350_remove_unused_indexes.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="kirsty.land@softwire.com" id="0021_EROPSPT-350_remove_application_id_gss_code_and_application_id_status_index" context="ddl">
+        <dropIndex tableName="postal_vote_application" indexName="postal_vote_application_application_id_status_idx"/>
+        <dropIndex tableName="postal_vote_application" indexName="postal_vote_application_application_id_gss_code_idx"/>
+        <dropIndex tableName="postal_vote_application" indexName="postal_vote_application_gss_code_idx"/>
+        <dropIndex tableName="proxy_vote_application" indexName="proxy_vote_application_application_id_status_idx"/>
+        <dropIndex tableName="proxy_vote_application" indexName="proxy_vote_application_application_id_gss_code_idx"/>
+        <dropIndex tableName="proxy_vote_application" indexName="proxy_vote_application_gss_code_idx"/>
+
+        <rollback>
+            <createIndex tableName="postal_vote_application" indexName="postal_vote_application_application_id_status_idx">
+                <column name="application_id"/>
+                <column name="status"/>
+            </createIndex>
+            <createIndex tableName="postal_vote_application" indexName="postal_vote_application_application_id_gss_code_idx">
+                <column name="application_id"/>
+                <column name="gss_code"/>
+            </createIndex>
+            <createIndex tableName="postal_vote_application" indexName="postal_vote_application_gss_code_idx">
+                <column name="gss_code"/>
+            </createIndex>
+            <createIndex tableName="proxy_vote_application" indexName="proxy_vote_application_application_id_status_idx">
+                <column name="application_id"/>
+                <column name="status"/>
+            </createIndex>
+            <createIndex tableName="proxy_vote_application" indexName="proxy_vote_application_application_id_gss_code_idx">
+                <column name="application_id"/>
+                <column name="gss_code"/>
+            </createIndex>
+            <createIndex tableName="proxy_vote_application" indexName="proxy_vote_application_gss_code_idx">
+                <column name="gss_code"/>
+            </createIndex>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/create/0022_EROPSPT-350_add_index_on_status.xml
+++ b/src/main/resources/db/changelog/create/0022_EROPSPT-350_add_index_on_status.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="kirsty.land@softwire.com" id="0022_EROPSPT-350_add_index_on_status_to_postal"
+               context="ddl">
+
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="postal_vote_application" indexName="postal_vote_application_status_idx" />
+            </not>
+        </preConditions>
+
+        <createIndex tableName="postal_vote_application"
+                     indexName="postal_vote_application_status_idx">
+            <column name="status"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="postal_vote_application"
+                       indexName="postal_vote_application_status_idx"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="kirsty.land@softwire.com" id="0022_EROPSPT-350_add_index_on_status_to_proxy"
+               context="ddl">
+
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="proxy_vote_application" indexName="proxy_vote_application_status_idx" />
+            </not>
+        </preConditions>
+
+        <createIndex tableName="proxy_vote_application"
+                     indexName="proxy_vote_application_status_idx">
+            <column name="status"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="proxy_vote_application"
+                       indexName="proxy_vote_application_status_idx"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -39,3 +39,7 @@ databaseChangeLog:
       file: /db/changelog/create/0019_EROPSPT-298_add_shedlock_table.xml
   - include:
       file: /db/changelog/create/0020_EROPSPT-298_remove_date_created_index.xml
+  - include:
+      file: /db/changelog/create/0021_EROPSPT-350_remove_unused_indexes.xml
+  - include:
+      file: /db/changelog/create/0022_EROPSPT-350_add_index_on_status.xml


### PR DESCRIPTION
Remove indexes:
 - on application_id and gss_code - application_id is the primary key so this doesn't seem like it should be very useful
 - on application_id and status - again, application_id is the primary key so it is hard to see how this could be useful
 - on gss_code - there is an index on (gss_code, status, date_created) which is used for the most common queries, and I think this should be sufficient for occasional manual queries by gss_code only

Add an index on status to help getting a breakdown of applications in RECEIVED state - this will probably want adding manually to the live table as it will take more than a minute to run.