### PR TITLE
EROPSPT-298: Re-enable Monitoring Pending Downloads job

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,10 +41,10 @@ api:
     sts.assume.role: ${API_IER_STS_ASSUME_ROLE}
 
 jobs:
-  enabled: false
+  enabled: true
   lock-at-most-for: "PT100M" # Time Period of 100 Minutes
   pending-downloads-monitoring:
-    enabled: false
+    enabled: true
     name: "PendingDownloadsMonitoring"
     cron: "0 0 5 * * *" # Runs at 05:00 daily
     expected-maximum-pending-period: 5D


### PR DESCRIPTION
Hopefully once the status index is added, this job should run fine. I'll double check by running the queries manually once the index has been created manually - but I'll probably leave that until just before the next release.