### PR TITLE
EIP1-11125: handling application not found on removal message

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageService.kt
@@ -38,7 +38,13 @@ class ProcessIntegrationDataRemovalMessageService(
                         logger.info { "Deleting $POSTAL application ems data with id = ${it.applicationId}" }
                         postalVoteApplicationRepository.delete(it)
                     }
-                }.orElseThrow { ApplicationNotFoundException(applicationId, ApplicationType.POSTAL) }
+                }.or {
+
+                    logger.warn {
+                        "ApplicationId $applicationId of type ${ApplicationType.POSTAL} was not found to delete"
+                    }
+                    Optional.empty()
+                }
             }
     }
 
@@ -52,7 +58,13 @@ class ProcessIntegrationDataRemovalMessageService(
                         logger.info { "Deleting $PROXY application ems data with id = ${it.applicationId}" }
                         proxyVoteApplicationRepository.delete(it)
                     }
-                }.orElseThrow { ApplicationNotFoundException(applicationId, ApplicationType.PROXY) }
+                }.or {
+
+                    logger.warn {
+                        "ApplicationId $applicationId of type ${ApplicationType.POSTAL} was not found to delete"
+                    }
+                    Optional.empty()
+                }
             }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.dluhc.emsintegrationapi.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
@@ -64,7 +65,7 @@ class ProcessIntegrationDataRemovalMessageServiceTest {
     }
 
     @Test
-    fun `should reject postal integration data removal message where application not found`() {
+    fun `should log warning when consuming postal integration data removal message where application not found`() {
         val applicationId = "123"
         val postalVoteApplication = mock(PostalVoteApplication::class.java)
         val message = RemoveApplicationEmsIntegrationDataMessage(
@@ -76,11 +77,7 @@ class ProcessIntegrationDataRemovalMessageServiceTest {
         given(postalVoteApplicationRepository.findById(anyString())).willReturn(Optional.empty())
 
         // When
-        assertThat(
-            assertThrows<ApplicationNotFoundException> {
-                service.process(message)
-            }.message
-        ).isEqualTo("The Postal application could not be found with id `$applicationId`")
+        assertDoesNotThrow { service.process(message) }
 
         // Then
         verify(postalVoteApplicationRepository, never()).delete(postalVoteApplication)
@@ -142,7 +139,7 @@ class ProcessIntegrationDataRemovalMessageServiceTest {
     }
 
     @Test
-    fun `should reject proxy integration data removal message where application not found`() {
+    fun `should log warning when consuming proxy integration data removal message where application not found`() {
         val applicationId = "123"
         val proxyVoteApplication = mock(ProxyVoteApplication::class.java)
         val message = RemoveApplicationEmsIntegrationDataMessage(
@@ -154,11 +151,7 @@ class ProcessIntegrationDataRemovalMessageServiceTest {
         given(proxyVoteApplicationRepository.findById(anyString())).willReturn(Optional.empty())
 
         // When
-        assertThat(
-            assertThrows<ApplicationNotFoundException> {
-                service.process(message)
-            }.message
-        ).isEqualTo("The Proxy application could not be found with id `$applicationId`")
+        assertDoesNotThrow { service.process(message) }
 
         // Then
         verify(proxyVoteApplicationRepository, never()).delete(proxyVoteApplication)


### PR DESCRIPTION
This is addressing a new acceptance criterion on https://mhclgdigital.atlassian.net/browse/EIP1-11125 :

> If a message is received on the remove-application-ems-integration-data queue and the application is not found then no exception is thrown and a warning message is logged

[See former PR](https://github.com/communitiesuk/eip-ero-ems-integration-api/pull/102).