### PR TITLE
EIP1-11025: correct application type on integration data removal warn logging statement

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageService.kt
@@ -61,7 +61,7 @@ class ProcessIntegrationDataRemovalMessageService(
                 }.or {
 
                     logger.warn {
-                        "ApplicationId $applicationId of type ${ApplicationType.POSTAL} was not found to delete"
+                        "ApplicationId $applicationId of type ${ApplicationType.PROXY} was not found to delete"
                     }
                     Optional.empty()
                 }


### PR DESCRIPTION
Tiny fix to correct logging message for proxy applications where application not found.

See https://mhclgdigital.atlassian.net/browse/EIP1-11025 for context.