### PR TITLE
EIP1-11125: correct application type on data removal warn logging statement

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageService.kt
@@ -61,7 +61,7 @@ class ProcessIntegrationDataRemovalMessageService(
                 }.or {
 
                     logger.warn {
-                        "ApplicationId $applicationId of type ${ApplicationType.POSTAL} was not found to delete"
+                        "ApplicationId $applicationId of type ${ApplicationType.PROXY} was not found to delete"
                     }
                     Optional.empty()
                 }


### PR DESCRIPTION
Correct application type that is logged when an application id for a proxy application supplied in a remove integration data message does not match to an existing application.  