### PR TITLE
EIP1-11125: correct logging message

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProcessIntegrationDataRemovalMessageService.kt
@@ -20,7 +20,7 @@ class ProcessIntegrationDataRemovalMessageService(
     @Transactional
     fun process(removeEmsDataMessage: RemoveApplicationEmsIntegrationDataMessage) {
         with(removeEmsDataMessage) {
-            logger.info { "Processing postal vote application with id = ${removeEmsDataMessage.applicationId}" }
+            logger.info { "Processing ${removeEmsDataMessage.source} vote application with id = ${removeEmsDataMessage.applicationId}" }
             when (removeEmsDataMessage.source) {
                 POSTAL -> processPostalApplicationRemoval(removeEmsDataMessage.applicationId)
                 PROXY -> processProxyApplicationRemoval(removeEmsDataMessage.applicationId)


### PR DESCRIPTION
Logging message on processing a remove integration data message showed postal type application in every case whereas it should show postal or proxy depending on the context.  This has now been corrected to use `removeEmsDataMessage.source` enumerated value interpolated into the string logging output.

See JIRA item https://mhclgdigital.atlassian.net/browse/EIP1-11125.