### PR TITLE
EIP1-11198: Update service to support req/res messages from the Appli…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,8 @@ dependencies {
     // AWS signer using SDK V2 library is available at https://mvnrepository.com/artifact/io.github.acm19/aws-request-signing-apache-interceptor/2.1.1
     implementation("io.github.acm19:aws-request-signing-apache-interceptor:2.1.1")
 
+    implementation("uk.gov.dluhc:messaging-support-library:2.1.0")
+
     // Test implementations
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,8 +110,6 @@ dependencies {
     // AWS signer using SDK V2 library is available at https://mvnrepository.com/artifact/io.github.acm19/aws-request-signing-apache-interceptor/2.1.1
     implementation("io.github.acm19:aws-request-signing-apache-interceptor:2.1.1")
 
-    implementation("uk.gov.dluhc:messaging-support-library:2.1.0")
-
     // Test implementations
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/QueueConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/QueueConfiguration.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.Companion.SQS_CONFIGURATION_PREFIX
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.DELETED_POSTAL_APPLICATION_QUEUE
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.DELETED_PROXY_APPLICATION_QUEUE
+import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.POSTAL_APPLICATION_QUEUE
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.PROXY_APPLICATION_QUEUE
 
@@ -17,6 +18,7 @@ class QueueConfiguration(
     private val postalApplicationQueueName: String,
     private val deletedProxyApplicationQueueName: String,
     private val deletedPostalApplicationQueueName: String,
+    private val emsApplicationProcessedQueueName: String,
 ) {
     companion object {
         const val SQS_CONFIGURATION_PREFIX = "sqs"
@@ -28,6 +30,7 @@ class QueueConfiguration(
             PROXY_APPLICATION_QUEUE -> proxyApplicationQueueName
             DELETED_POSTAL_APPLICATION_QUEUE -> deletedPostalApplicationQueueName
             DELETED_PROXY_APPLICATION_QUEUE -> deletedProxyApplicationQueueName
+            EMS_APPLICATION_PROCESSED_QUEUE -> emsApplicationProcessedQueueName
         }
     }
 
@@ -36,5 +39,6 @@ class QueueConfiguration(
         PROXY_APPLICATION_QUEUE,
         DELETED_POSTAL_APPLICATION_QUEUE,
         DELETED_PROXY_APPLICATION_QUEUE,
+        EMS_APPLICATION_PROCESSED_QUEUE
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/PostalVoteApplication.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/PostalVoteApplication.kt
@@ -86,6 +86,8 @@ class PostalVoteApplication(
     )
     var welshRejectedReasonItems: Set<RejectedReasonItem>? = mutableSetOf(),
 
+    val isFromApplicationsApi: Boolean?,
+
     @Version
     var version: Long? = null,
 ) {

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/PostalVoteApplication.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/PostalVoteApplication.kt
@@ -86,7 +86,7 @@ class PostalVoteApplication(
     )
     var welshRejectedReasonItems: Set<RejectedReasonItem>? = mutableSetOf(),
 
-    val isFromApplicationsApi: Boolean?,
+    var isFromApplicationsApi: Boolean?,
 
     @Version
     var version: Long? = null,

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/ProxyVoteApplication.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/ProxyVoteApplication.kt
@@ -72,6 +72,8 @@ class ProxyVoteApplication(
     )
     var welshRejectedReasonItems: Set<RejectedReasonItem>? = mutableSetOf(),
 
+    val isFromApplicationsApi: Boolean?,
+
     @Version
     var version: Long? = null,
 ) {

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/ProxyVoteApplication.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/ProxyVoteApplication.kt
@@ -72,7 +72,7 @@ class ProxyVoteApplication(
     )
     var welshRejectedReasonItems: Set<RejectedReasonItem>? = mutableSetOf(),
 
-    val isFromApplicationsApi: Boolean?,
+    var isFromApplicationsApi: Boolean?,
 
     @Version
     var version: Long? = null,

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/PostalVoteApplicationMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/PostalVoteApplicationMessageMapper.kt
@@ -37,6 +37,7 @@ class PostalVoteApplicationMessageMapper(
                 englishRejectedReasonItems = it.postalVoteDetails?.rejectedReasons?.englishReason?.reasonList?.map { RejectedReasonItemEntity(it.electorReason, it.type, it.includeInComms) }?.toSet(),
                 welshRejectionNotes = it.postalVoteDetails?.rejectedReasons?.welshReason?.notes,
                 welshRejectedReasonItems = it.postalVoteDetails?.rejectedReasons?.welshReason?.reasonList?.map { RejectedReasonItemEntity(it.electorReason, it.type, it.includeInComms) }?.toSet(),
+                isFromApplicationsApi = it.isFromApplicationsApi,
             )
         }
 }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/ProxyVoteApplicationMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/ProxyVoteApplicationMessageMapper.kt
@@ -32,6 +32,7 @@ class ProxyVoteApplicationMessageMapper(
                 englishRejectedReasonItems = it.proxyVoteDetails.rejectedReasons?.englishReason?.reasonList?.map { RejectedReasonItemEntity(it.electorReason, it.type, it.includeInComms) }?.toSet(),
                 welshRejectionNotes = it.proxyVoteDetails.rejectedReasons?.welshReason?.notes,
                 welshRejectedReasonItems = it.proxyVoteDetails.rejectedReasons?.welshReason?.reasonList?.map { RejectedReasonItemEntity(it.electorReason, it.type, it.includeInComms) }?.toSet(),
+                isFromApplicationsApi = it.isFromApplicationsApi,
             )
         }
 }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/AbstractApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/AbstractApplicationService.kt
@@ -32,7 +32,7 @@ abstract class AbstractApplicationService(
     }
 
     protected fun sendMessage(request: EMSApplicationResponse, applicationId: String, isFromApplicationsApi: Boolean? = null) {
-        val targetQueueName = isFromApplicationsApi?.takeIf { it }?.let { QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE } ?: queueName
+        val targetQueueName = if (isFromApplicationsApi == true) QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE else queueName
         messageSender.send(
             EmsConfirmedReceiptMessage(
                 id = applicationId,

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/AbstractApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/AbstractApplicationService.kt
@@ -31,7 +31,8 @@ abstract class AbstractApplicationService(
         }
     }
 
-    protected fun sendMessage(request: EMSApplicationResponse, applicationId: String) {
+    protected fun sendMessage(request: EMSApplicationResponse, applicationId: String, queueNameOverride: QueueConfiguration.QueueName? = null) {
+        val targetQueueName = queueNameOverride ?: queueName
         messageSender.send(
             EmsConfirmedReceiptMessage(
                 id = applicationId,
@@ -42,7 +43,7 @@ abstract class AbstractApplicationService(
                 message = request.message,
                 details = request.details
             ),
-            queueName
+            targetQueueName
         )
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/AbstractApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/AbstractApplicationService.kt
@@ -31,8 +31,8 @@ abstract class AbstractApplicationService(
         }
     }
 
-    protected fun sendMessage(request: EMSApplicationResponse, applicationId: String, queueNameOverride: QueueConfiguration.QueueName? = null) {
-        val targetQueueName = queueNameOverride ?: queueName
+    protected fun sendMessage(request: EMSApplicationResponse, applicationId: String, isFromApplicationsApi: Boolean? = null) {
+        val targetQueueName = isFromApplicationsApi?.takeIf { it }?.let { QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE } ?: queueName
         messageSender.send(
             EmsConfirmedReceiptMessage(
                 id = applicationId,

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationService.kt
@@ -80,8 +80,11 @@ class PostalVoteApplicationService(
             updatedBy = SourceSystem.EMS
             doConfirmedReceiptApplicationStatus(request, postalVoteApplication.applicationDetails)
         }
-
-        sendMessage(request, postalVoteApplication.applicationId)
+        if (postalVoteApplication.isFromApplicationsApi == true) {
+            sendMessage(request, postalVoteApplication.applicationId, QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE)
+        } else {
+            sendMessage(request, postalVoteApplication.applicationId)
+        }
 
         logger.info { "Confirmation ${request.status} message sent to the postal vote application for ${postalVoteApplication.applicationId}" }
     }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationService.kt
@@ -80,11 +80,8 @@ class PostalVoteApplicationService(
             updatedBy = SourceSystem.EMS
             doConfirmedReceiptApplicationStatus(request, postalVoteApplication.applicationDetails)
         }
-        if (postalVoteApplication.isFromApplicationsApi == true) {
-            sendMessage(request, postalVoteApplication.applicationId, QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE)
-        } else {
-            sendMessage(request, postalVoteApplication.applicationId)
-        }
+
+        sendMessage(request, postalVoteApplication.applicationId, postalVoteApplication.isFromApplicationsApi)
 
         logger.info { "Confirmation ${request.status} message sent to the postal vote application for ${postalVoteApplication.applicationId}" }
     }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationService.kt
@@ -82,11 +82,7 @@ class ProxyVoteApplicationService(
             doConfirmedReceiptApplicationStatus(request, proxyVoteApplication.applicationDetails)
         }
 
-        if (proxyVoteApplication.isFromApplicationsApi == true) {
-            sendMessage(request, proxyVoteApplication.applicationId, QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE)
-        } else {
-            sendMessage(request, proxyVoteApplication.applicationId)
-        }
+        sendMessage(request, proxyVoteApplication.applicationId, proxyVoteApplication.isFromApplicationsApi)
 
         logger.info { "Confirmation ${request.status} message sent to the proxy vote application for ${proxyVoteApplication.applicationId}" }
     }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationService.kt
@@ -82,7 +82,11 @@ class ProxyVoteApplicationService(
             doConfirmedReceiptApplicationStatus(request, proxyVoteApplication.applicationDetails)
         }
 
-        sendMessage(request, proxyVoteApplication.applicationId)
+        if (proxyVoteApplication.isFromApplicationsApi == true) {
+            sendMessage(request, proxyVoteApplication.applicationId, QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE)
+        } else {
+            sendMessage(request, proxyVoteApplication.applicationId)
+        }
 
         logger.info { "Confirmation ${request.status} message sent to the proxy vote application for ${proxyVoteApplication.applicationId}" }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,7 @@ sqs:
   deleted-proxy-application-queue-name: ${SQS_DELETED_PROXY_APPLICATION_QUEUE_NAME}
   deleted-postal-application-queue-name: ${SQS_DELETED_POSTAL_APPLICATION_QUEUE_NAME}
   remove-application-ems-integration-data-queue-name: ${SQS_REMOVE_APPLICATION_EMS_DATA_QUEUE_NAME}
+  ems-application-processed-queue-name: ${SQS_EMS_APPLICATION_PROCESSED_QUEUE_NAME}
 
 
 api:

--- a/src/main/resources/db/changelog/create/0023_EIP1-11198_add-is-from-applications-api-flag.xml
+++ b/src/main/resources/db/changelog/create/0023_EIP1-11198_add-is-from-applications-api-flag.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="esengul.gungor@softwire.com" id="023_EIP1-11198_add-is-from-applications-api-flag" context="ddl">
+        <addColumn tableName="postal_vote_application">
+            <column name="is_from_applications_api" type="bit(1)" defaultValueNumeric="0"/>
+        </addColumn>
+
+        <addColumn tableName="proxy_vote_application">
+            <column name="is_from_applications_api" type="bit(1)" defaultValueNumeric="0"/>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="postal_vote_application" columnName="is_from_applications_api" />
+            <dropColumn tableName="proxy_vote_application" columnName="is_from_applications_api" />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/create/0023_EIP1-11198_add-is-from-applications-api-flag.xml
+++ b/src/main/resources/db/changelog/create/0023_EIP1-11198_add-is-from-applications-api-flag.xml
@@ -5,18 +5,24 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
 
-    <changeSet author="esengul.gungor@softwire.com" id="023_EIP1-11198_add-is-from-applications-api-flag" context="ddl">
+    <changeSet author="esengul.gungor@softwire.com" id="023_EIP1-11198_add-is-from-applications-api-flag-to-postal" context="ddl">
         <addColumn tableName="postal_vote_application">
-            <column name="is_from_applications_api" type="bit(1)" defaultValueNumeric="0"/>
-        </addColumn>
-
-        <addColumn tableName="proxy_vote_application">
-            <column name="is_from_applications_api" type="bit(1)" defaultValueNumeric="0"/>
+            <column name="is_from_applications_api" type="bit(1)"/>
         </addColumn>
 
         <rollback>
             <dropColumn tableName="postal_vote_application" columnName="is_from_applications_api" />
+        </rollback>
+    </changeSet>
+
+    <changeSet author="esengul.gungor@softwire.com" id="023_EIP1-11198_add-is-from-applications-api-flag-to-proxy" context="ddl">
+        <addColumn tableName="proxy_vote_application">
+            <column name="is_from_applications_api" type="bit(1)"/>
+        </addColumn>
+
+        <rollback>
             <dropColumn tableName="proxy_vote_application" columnName="is_from_applications_api" />
         </rollback>
     </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -43,3 +43,5 @@ databaseChangeLog:
       file: /db/changelog/create/0021_EROPSPT-350_remove_unused_indexes.xml
   - include:
       file: /db/changelog/create/0022_EROPSPT-350_add_index_on_status.xml
+  - include:
+      file: db/changelog/create/0023_EIP1-11198_add-is-from-applications-api-flag.xml

--- a/src/main/resources/openapi/sqs/postal-vote-application-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/postal-vote-application-sqs-messaging.yaml
@@ -222,6 +222,7 @@ components:
               uprn: '098766'
             ballotAddressReason: I am away from home for work
             voteUntilFurtherNotice: true
+          isFromApplicationsApi: false
       properties:
         applicationDetails:
           $ref: './Models/ApplicationDetails.yaml'
@@ -231,7 +232,9 @@ components:
           $ref: '#/components/schemas/PostalVoteDetails'
         primaryElectorDetails:
           $ref: '#/components/schemas/PrimaryElectorDetails'
-
+        isFromApplicationsApi:
+          type: boolean
+          description: It indicates that the message comes from Applications Api or not
       required:
         - applicationDetails
         - applicantDetails

--- a/src/main/resources/openapi/sqs/postal-vote-application-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/postal-vote-application-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Approved/Rejected Postal Application SQS Message
-  version: 1.2.1
+  version: 1.2.2
   description: |-
     Approved/Rejected Postal application API SQS Message Types for EROP
 

--- a/src/main/resources/openapi/sqs/proxy-vote-application-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/proxy-vote-application-sqs-messaging.yaml
@@ -163,7 +163,7 @@ components:
             proxyEmail: jane@example.com
             proxyReason: work commitments
             voteUntilFurtherNotice: true
-
+          isFromApplicationsApi: false
       properties:
         applicationDetails:
           $ref: './Models/ApplicationDetails.yaml'
@@ -171,6 +171,9 @@ components:
           $ref: './Models/ApplicantDetails.yaml'
         proxyVoteDetails:
           $ref: '#/components/schemas/ProxyVoteDetails'
+        isFromApplicationsApi:
+          type: boolean
+          description: It indicates that the message comes from Applications Api or not
       required:
         - applicationDetails
         - applicantDetails

--- a/src/main/resources/openapi/sqs/proxy-vote-application-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/proxy-vote-application-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Approved/Rejected Proxy Application SQS Message
-  version: 1.2.2
+  version: 1.2.3
   description: |-
     Approved/Rejected Proxy application API SQS Message Types for EROP
 

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/config/QueueConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/config/QueueConfigurationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.DELETED_POSTAL_APPLICATION_QUEUE
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.DELETED_PROXY_APPLICATION_QUEUE
+import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.POSTAL_APPLICATION_QUEUE
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.PROXY_APPLICATION_QUEUE
 
@@ -15,7 +16,8 @@ internal class QueueConfigurationTest {
             PROXY_APPLICATION_QUEUE.name,
             POSTAL_APPLICATION_QUEUE.name,
             DELETED_PROXY_APPLICATION_QUEUE.name,
-            DELETED_POSTAL_APPLICATION_QUEUE.name
+            DELETED_POSTAL_APPLICATION_QUEUE.name,
+            EMS_APPLICATION_PROCESSED_QUEUE.name,
         )
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/PostalVoteApplicationRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/PostalVoteApplicationRepositoryIntegrationTest.kt
@@ -34,13 +34,43 @@ class PostalVoteApplicationRepositoryIntegrationTest : AbstractRepositoryIntegra
     }
 
     @Test
+    fun `should save a postal vote application when isFromApplicationsApi is false`() {
+        // Given
+        val postalVoteApplication = buildPostalVoteApplication(isFromApplicationsApi = false)
+
+        // When
+        postalVoteApplicationRepository.saveAndFlush(postalVoteApplication)
+
+        // Then
+        val savedApplication =
+            postalVoteApplicationRepository.findById(postalVoteApplication.applicationId).get()
+
+        assertThat(savedApplication).usingRecursiveComparison().isEqualTo(postalVoteApplication)
+    }
+
+    @Test
+    fun `should save a postal vote application when isFromApplicationsApi is true`() {
+        // Given
+        val postalVoteApplication = buildPostalVoteApplication(isFromApplicationsApi = true)
+
+        // When
+        postalVoteApplicationRepository.saveAndFlush(postalVoteApplication)
+
+        // Then
+        val savedApplication =
+            postalVoteApplicationRepository.findById(postalVoteApplication.applicationId).get()
+
+        assertThat(savedApplication).usingRecursiveComparison().isEqualTo(postalVoteApplication)
+    }
+
+    @Test
     fun `should return records by gss codes and record status order by created date using two step process`() {
         // Given
         val listOfApplications =
             IntStream.rangeClosed(1, 30).mapToObj {
                 buildPostalVoteApplication(
                     applicationId = it.toString(),
-                    buildApplicationDetailsEntity(gssCode = faker.options().option(GSS_CODE, GSS_CODE2))
+                    buildApplicationDetailsEntity(gssCode = faker.options().option(GSS_CODE, GSS_CODE2)),
                 )
             }.toList()
 

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/ProxyVoteApplicationRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/ProxyVoteApplicationRepositoryIntegrationTest.kt
@@ -35,6 +35,36 @@ class ProxyVoteApplicationRepositoryIntegrationTest : AbstractRepositoryIntegrat
     }
 
     @Test
+    fun `should save a proxy vote application when isFromApplicationsApi is true`() {
+        // Given
+        val proxyVoteApplication = buildProxyVoteApplication(isFromApplicationsApi = true)
+
+        // When
+        proxyVoteApplicationRepository.saveAndFlush(proxyVoteApplication)
+
+        // Then
+        val savedApplication =
+            proxyVoteApplicationRepository.findById(proxyVoteApplication.applicationId).get()
+
+        assertThat(savedApplication).usingRecursiveComparison().isEqualTo(proxyVoteApplication)
+    }
+
+    @Test
+    fun `should save a proxy vote application when isFromApplicationsApi is false`() {
+        // Given
+        val proxyVoteApplication = buildProxyVoteApplication(isFromApplicationsApi = false)
+
+        // When
+        proxyVoteApplicationRepository.saveAndFlush(proxyVoteApplication)
+
+        // Then
+        val savedApplication =
+            proxyVoteApplicationRepository.findById(proxyVoteApplication.applicationId).get()
+
+        assertThat(savedApplication).usingRecursiveComparison().isEqualTo(proxyVoteApplication)
+    }
+
+    @Test
     fun `should return records by gss codes and record status order by created date using two step process`() {
         // Given
 

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/PostalVoteApplicationMessageMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/PostalVoteApplicationMessageMapperTest.kt
@@ -46,6 +46,7 @@ internal class PostalVoteApplicationMessageMapperTest {
                 assertThat(it.output.englishRejectedReasonItems?.isNotEmpty())
                 assertThat(it.output.welshRejectionNotes).isNotNull()
                 assertThat(it.output.welshRejectedReasonItems?.isNotEmpty())
+                assertThat(it.output.isFromApplicationsApi).isNull()
             }
         }
 
@@ -58,13 +59,15 @@ internal class PostalVoteApplicationMessageMapperTest {
                         ballotAddress = null,
                         ballotOverseasAddress = null,
                         ballotBfpoAddress = null
-                    )
+                    ),
+                    isFromApplicationsApi = true
                 )
             val postalVoteApplication: PostalVoteApplication = postalVoteApplicationMessageMapper.mapToEntity(applicationMessage)
             assertThat(postalVoteApplication.applicantDetails.registeredAddress.createdBy).isEqualTo(SourceSystem.POSTAL)
             assertThat(postalVoteApplication.postalVoteDetails?.ballotAddress).isNull()
             assertThat(postalVoteApplication.postalVoteDetails?.ballotOverseasAddress).isNull()
             assertThat(postalVoteApplication.postalVoteDetails?.ballotBfpoAddress).isNull()
+            assertThat(postalVoteApplication.isFromApplicationsApi).isTrue
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/ProxyVoteApplicationMessageMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/ProxyVoteApplicationMessageMapperTest.kt
@@ -40,6 +40,7 @@ internal class ProxyVoteApplicationMessageMapperTest {
                 assertThat(it.output.englishRejectedReasonItems?.isNotEmpty())
                 assertThat(it.output.welshRejectionNotes).isNotNull()
                 assertThat(it.output.welshRejectedReasonItems?.isNotEmpty())
+                assertThat(it.output.isFromApplicationsApi).isNull()
             }
         }
     }
@@ -55,7 +56,8 @@ internal class ProxyVoteApplicationMessageMapperTest {
                         welshNotes = null,
                         welshReason = null
                     )
-                )
+                ),
+                isFromApplicationsApi = true,
             )
         val proxyVoteApplication: ProxyVoteApplication = proxyVoteApplicationMessageMapper.mapToEntity(applicationMessage)
         assertThat(proxyVoteApplication.applicantDetails.registeredAddress.createdBy).isEqualTo(SourceSystem.PROXY)
@@ -63,5 +65,6 @@ internal class ProxyVoteApplicationMessageMapperTest {
         assertThat(proxyVoteApplication.englishRejectedReasonItems?.isNotEmpty())
         assertThat(proxyVoteApplication.welshRejectionNotes).isNull()
         assertThat(proxyVoteApplication.welshRejectedReasonItems).isNull()
+        assertThat(proxyVoteApplication.isFromApplicationsApi).isTrue()
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
@@ -219,6 +219,32 @@ internal class ProxyVoteApplicationServiceTest {
         }
 
         @Test
+        fun `should send SUCCESS confirmation message to EMS_APPLICATION_PROCESSED_QUEUE `() {
+            // Given
+            val proxyVoteApplication = buildProxyVoteApplication(isFromApplicationsApi = true)
+            given(
+                proxyVoteApplicationRepository.findByApplicationIdAndApplicationDetailsGssCodeIn(
+                    proxyVoteApplication.applicationId,
+                    GSS_CODES
+                )
+            ).willReturn(proxyVoteApplication)
+            // When
+            proxyVoteApplicationService.confirmReceipt(
+                CERTIFICATE_SERIAL_NUMBER, proxyVoteApplication.applicationId,
+                requestSuccess
+            )
+
+            // Then
+            verify(messageSender).send(
+                EmsConfirmedReceiptMessage(
+                    proxyVoteApplication.applicationId,
+                    EmsConfirmedReceiptMessage.Status.SUCCESS
+                ),
+                QueueConfiguration.QueueName.EMS_APPLICATION_PROCESSED_QUEUE
+            )
+        }
+
+        @Test
         fun `should update the record status to be DELETED and send FAILURE confirmation message`() {
             // Given
             val proxyVoteApplication = buildProxyVoteApplication()

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/testsupport/testdata/PostalVoteApplicationBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/testsupport/testdata/PostalVoteApplicationBuilder.kt
@@ -31,7 +31,8 @@ fun buildPostalVoteApplication(
     englishRejectionNotes: String? = null,
     englishRejectedReasonItems: Set<RejectedReasonItem>? = emptySet(),
     welshRejectionNotes: String? = null,
-    welshRejectedReasonItems: Set<RejectedReasonItem>? = emptySet()
+    welshRejectedReasonItems: Set<RejectedReasonItem>? = emptySet(),
+    isFromApplicationsApi: Boolean? = null,
 ) = PostalVoteApplication(
     applicationId = applicationId,
     applicationDetails = applicationDetails,
@@ -47,7 +48,8 @@ fun buildPostalVoteApplication(
     englishRejectionNotes = englishRejectionNotes,
     englishRejectedReasonItems = englishRejectedReasonItems,
     welshRejectionNotes = welshRejectionNotes,
-    welshRejectedReasonItems = welshRejectedReasonItems
+    welshRejectedReasonItems = welshRejectedReasonItems,
+    isFromApplicationsApi = isFromApplicationsApi
 )
 
 fun buildPostalVoteApplicationMessage(
@@ -55,9 +57,11 @@ fun buildPostalVoteApplicationMessage(
     applicantDetails: ApplicantDetailsMessageDto = buildApplicantDetailsMessageDto(),
     postalVoteDetails: PostalVoteDetailsMessageDto = buildPostalVoteDetailsMessageDto(),
     primaryElectorDetails: PrimaryElectorDetailsMessageDto? = null,
+    isFromApplicationsApi: Boolean? = null,
 ) = PostalVoteApplicationMessage(
     applicationDetails = applicationDetails,
     applicantDetails = applicantDetails,
     postalVoteDetails = postalVoteDetails,
     primaryElectorDetails = primaryElectorDetails,
+    isFromApplicationsApi = isFromApplicationsApi
 )

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/testsupport/testdata/ProxyVoteApplicationBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/testsupport/testdata/ProxyVoteApplicationBuilder.kt
@@ -29,6 +29,7 @@ fun buildProxyVoteApplication(
     englishRejectedReasonItems: Set<RejectedReasonItem>? = emptySet(),
     welshRejectionNotes: String? = null,
     welshRejectedReasonItems: Set<RejectedReasonItem>? = emptySet(),
+    isFromApplicationsApi: Boolean? = null,
 ) = ProxyVoteApplication(
     applicationId = applicationId,
     applicationDetails = applicationDetails,
@@ -43,15 +44,18 @@ fun buildProxyVoteApplication(
     englishRejectionNotes = englishRejectionNotes,
     englishRejectedReasonItems = englishRejectedReasonItems,
     welshRejectionNotes = welshRejectionNotes,
-    welshRejectedReasonItems = welshRejectedReasonItems
+    welshRejectedReasonItems = welshRejectedReasonItems,
+    isFromApplicationsApi = isFromApplicationsApi
 )
 
 fun buildProxyVoteApplicationMessageDto(
     applicationDetails: ApplicationDetailsMessageDto = buildApplicationDetailsMessageDto(),
     applicantDetails: ApplicantDetailsMessageDto = buildApplicantDetailsMessageDto(),
     proxyVoteDetails: ProxyVoteDetailsMessageDto = buildProxyVoteDetailsMessageDto(),
+    isFromApplicationsApi: Boolean? = null,
 ) = ProxyVoteApplicationMessage(
     applicationDetails = applicationDetails,
     applicantDetails = applicantDetails,
     proxyVoteDetails = proxyVoteDetails,
+    isFromApplicationsApi = isFromApplicationsApi,
 )


### PR DESCRIPTION
**Describe your changes**

The ems_postal_application_queue and ems_proxy_application_queue are the queues that will receive messages from the Postal, Proxy, and Applications APIs. These APIs will send messages to these queues, including a new field: isFromApplicationsApi.

We also need to implement functionality to read messages from the existing request queues — ems_postal_application_queue and ems_proxy_application_queue — which will contain the isFromApplicationsApi field to indicate the source of the message.

In addition, we need to add functionality to send messages to the Applications API through the ems_application_processed_queue. If the isFromApplicationsApi field is true, the message will be sent to the ems_application_processed_queue for processing by the Applications API. If isFromApplicationsApi is false, the message will follow the existing implementation.

**Issue ticket number and link**

https://mhclgdigital.atlassian.net/browse/EIP1-11198
