### PR TITLE
IERSPPRT-1549: Add external ID to assume ier client role

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       API_ERO_MANAGEMENT_URL: http://wiremock:8080/ero-management-api
       API_IER_BASE_URL: http://wiremock:8080/ier-ero
       API_IER_STS_ASSUME_ROLE: arn:aws:iam::1234567890987:role/grant-me-access-to-ier
+      API_IER_STS_ASSUME_ROLE_EXTERNAL_ID: abc123
     depends_on:
       database:
         condition: service_healthy

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/IerRestTemplateConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/config/IerRestTemplateConfiguration.kt
@@ -26,6 +26,7 @@ import java.net.URI
 class IerRestTemplateConfiguration(
     @Value("\${api.ier.base.url}") private val ierApiBaseUrl: String,
     @Value("\${api.ier.sts.assume.role}") private val ierStsAssumeRole: String,
+    @Value("\${api.ier.sts.assume.role.external-id}") private val ierStsAssumeRoleExternalId: String,
     private val correlationIdRestTemplateClientHttpRequestInterceptor: CorrelationIdRestTemplateClientHttpRequestInterceptor,
 ) {
 
@@ -50,6 +51,7 @@ class IerRestTemplateConfiguration(
                 AssumeRoleRequest.builder()
                     .roleArn(ierStsAssumeRole)
                     .roleSessionName(STS_SESSION_NAME)
+                    .externalId(ierStsAssumeRoleExternalId)
                     .build()
             )
             .stsClient(stsClient)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,7 @@ api:
   ier:
     base.url: ${API_IER_BASE_URL}
     sts.assume.role: ${API_IER_STS_ASSUME_ROLE}
+    sts.assume.role.external-id: ${API_IER_STS_ASSUME_ROLE_EXTERNAL_ID}
 
 jobs:
   enabled: true

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -40,6 +40,7 @@ api:
   ier:
     base.url: http://replaced-by-wireMockServer-bean
     sts.assume.role: arn:aws:iam::1234567890987:role/grant-me-access-to-ier
+    sts.assume.role.external-id: abc123
 
 caching.time-to-live: PT2S
 


### PR DESCRIPTION
Associated infra changes here: https://github.com/communitiesuk/eip-ero-infra/pull/2305/files.
I've tested that these same changes work in the proxy api.

These changes have been duplicated in the following repos:
- eip-ero-applications-api: https://github.com/communitiesuk/eip-ero-applications-api/pull/82
- eip-ero-ems-integration-api: https://github.com/communitiesuk/eip-ero-ems-integration-api/pull/122
- eip-ero-management-api: https://github.com/communitiesuk/eip-ero-management-api/pull/168
- eip-ero-register-checker-api: https://github.com/communitiesuk/eip-ero-register-checker-api/pull/160
- eip-ero-overseas-applications-api: https://github.com/communitiesuk/eip-ero-overseas-applications-api/pull/395
- eip-ero-postal-applications-api: https://github.com/communitiesuk/eip-ero-postal-applications-api/pull/738
- eip-ero-voter-card-applications-api: https://github.com/communitiesuk/eip-ero-voter-card-applications-api/pull/856
- eip-ero-proxy-applications-api: https://github.com/communitiesuk/eip-ero-proxy-applications-api/pull/408