### PR TITLE
EIP1-NONE: Remove tag message when pushing tag to avoid escape issues

### DIFF
--- a/.github/workflows/build-image-and-deploy-to-dev.yml
+++ b/.github/workflows/build-image-and-deploy-to-dev.yml
@@ -51,7 +51,7 @@ jobs:
           tag=${{ steps.bump-semver.outputs.new_version }}
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git tag -a "${tag}" -m "${{ github.event.head_commit.message }}"
+          git tag "${tag}"
           git push origin "${tag}"
 
       # https://github.com/spring-projects/spring-boot/issues/39323


### PR DESCRIPTION
Issue is when there are `"` in the tag (commit) message, which is the default way `Revert` commits are formatted.

We have done the same fix of removing the tag message in other services for the same reason.