### PR TITLE
EIP1-11113: change some sqs queue configurations

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,17 +31,16 @@ sqs:
   postal-application-queue-name: ${SQS_POSTAL_APPLICATION_QUEUE_NAME}
   deleted-proxy-application-queue-name: ${SQS_DELETED_PROXY_APPLICATION_QUEUE_NAME}
   deleted-postal-application-queue-name: ${SQS_DELETED_POSTAL_APPLICATION_QUEUE_NAME}
-  remove-application-ems-integration-data-queue-name: ${SQS_REMOVE_APPLICATION_EMS_DATA_QUEUE_NAME}
+  remove-application-ems-integration-data-queue-name: ${SQS_REMOVE_APPLICATION_EMS_INTEGRATION_DATA_QUEUE_NAME}
   ems-application-processed-queue-name: ${SQS_EMS_APPLICATION_PROCESSED_QUEUE_NAME}
-  ems-cidr-update-queue-name: ${SQS_EMS_CIDR_UPDATE_QUEUE_NAME}
-  initiate-applicant-register-check-queue-name: ${SQS_INITIATE_APPLICANT_REGISTER_CHECK_QUEUE_NAME}
+  initiate-applicant-register-check-queue-name: ${SQS_INITIATE_REGISTER_CHECK_QUEUE_NAME}
   confirm-applicant-register-check-result-queue-name: ${SQS_CONFIRM_APPLICANT_REGISTER_CHECK_RESULT_QUEUE_NAME}
   postal-vote-confirm-applicant-register-check-result-queue-name: ${SQS_POSTAL_VOTE_CONFIRM_APPLICANT_REGISTER_CHECK_RESULT_QUEUE_NAME}
   proxy-vote-confirm-applicant-register-check-result-queue-name: ${SQS_PROXY_VOTE_CONFIRM_APPLICANT_REGISTER_CHECK_RESULT_QUEUE_NAME}
   overseas-vote-confirm-applicant-register-check-result-queue-name: ${SQS_OVERSEAS_VOTE_CONFIRM_APPLICANT_REGISTER_CHECK_RESULT_QUEUE_NAME}
   register-check-result-response-queue-name: ${SQS_REGISTER_CHECK_RESULT_RESPONSE_QUEUE_NAME}
   remove-applicant-register-check-data-queue-name: ${SQS_REMOVE_APPLICANT_REGISTER_CHECK_DATA_QUEUE_NAME}
-  pending-register-check-archive-queue-name: ${SQS_PENDING_REGISTER_CHECK_AERCHIVE_QUEUE_NAME}
+  pending-register-check-archive-queue-name: ${SQS_PENDING_REGISTER_CHECK_ARCHIVE_QUEUE_NAME}
 
 api:
   ero-management:


### PR DESCRIPTION
Made several corrections to env var expectations in `application.yml` for configuration of QS queues.

This PR is about making sure the ems integration api can deploy to DEV2 without infrastructural errors. It ties in with infra PR https://github.com/communitiesuk/eip-ero-infra/pull/2529 and should not be merged before that or the deployment will fail.