### PR TITLE
EROPSPT-443: Upgrade SB to 3.3.11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 import java.lang.ProcessBuilder.Redirect
 
 plugins {
-    id("org.springframework.boot") version "3.3.9"
+    id("org.springframework.boot") version "3.3.11"
     id("io.spring.dependency-management") version "1.1.3"
     kotlin("jvm") version "1.9.24"
     kotlin("kapt") version "1.9.24"


### PR DESCRIPTION
Upgrading SB to the latest 3.3 version. Resolves CVE-2025-22235 and CVE-2025-22228.